### PR TITLE
chore(ploke-db): unify backup import for always-on typed type graph

### DIFF
--- a/crates/ploke-db/Cargo.toml
+++ b/crates/ploke-db/Cargo.toml
@@ -52,4 +52,3 @@ ploke-common = { path = "../common" }
 [features]
 default = []
 type_bearing_ids = []
-typed_type_graph = ["syn_parser/typed_type_graph", "ploke-transform/typed_type_graph"]

--- a/crates/ploke-db/src/database.rs
+++ b/crates/ploke-db/src/database.rs
@@ -1539,39 +1539,20 @@ desc[id] := parent_of[id, parent], desc[parent], not file_root[id]
             .collect())
     }
 
-    /// Relation names for active plain fixtures that are shared between the legacy and typed
-    /// type-resolution build profiles.
+    /// Relation names for active plain fixtures that omit typed type graph relations
+    /// on import so legacy backup rows for `resolved_type_use` are ignored.
     ///
-    /// In the normal profile this includes `resolved_type_use`. In the `typed_type_graph`
-    /// profile, active non-typed fixtures intentionally do not claim typed type graph coverage, so
-    /// typed type graph relations remain empty after import. Typed graph corpus fixtures must use
+    /// Typed graph corpus fixtures must use
     /// [`Self::prior_rels_for_typed_type_graph_backup_import`] instead.
     pub fn prior_rels_for_plain_backup_import(&self) -> Result<Vec<String>, PlokeError> {
-        #[cfg(not(feature = "typed_type_graph"))]
-        {
-            self.prior_rels_for_current_schema_backup_import()
-        }
-
-        #[cfg(feature = "typed_type_graph")]
-        {
-            let mut relations = self.prior_rels_for_current_schema_backup_import()?;
-            relations.retain(|r| !is_typed_type_graph_relation(r));
-            Ok(relations)
-        }
+        let mut relations = self.prior_rels_for_current_schema_backup_import()?;
+        relations.retain(|r| !is_typed_type_graph_relation(r));
+        Ok(relations)
     }
 
     /// Relation names for source-pinned typed type graph backup fixtures.
     pub fn prior_rels_for_typed_type_graph_backup_import(&self) -> Result<Vec<String>, PlokeError> {
-        #[cfg(feature = "typed_type_graph")]
-        {
-            self.prior_rels_for_current_schema_backup_import()
-        }
-        #[cfg(not(feature = "typed_type_graph"))]
-        {
-            Err(PlokeError::from(DbError::Cozo(
-                "typed type graph backup import requires the typed_type_graph feature".to_string(),
-            )))
-        }
+        self.prior_rels_for_current_schema_backup_import()
     }
 
     // Gets all the file data in the same namespace as the crate name given as argument.

--- a/crates/ploke-db/tests/unit/mod.rs
+++ b/crates/ploke-db/tests/unit/mod.rs
@@ -4,5 +4,4 @@ pub mod index_test;
 pub mod method_embeddable;
 #[cfg(feature = "type_bearing_ids")]
 pub mod test_queries;
-#[cfg(feature = "typed_type_graph")]
 pub mod type_graph_queries;

--- a/crates/ploke-db/tests/unit/type_graph_queries/mod.rs
+++ b/crates/ploke-db/tests/unit/type_graph_queries/mod.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "typed_type_graph")]
 //! Type graph query contracts for graphRAG-oriented Rust code traversal.
 //!
 //! This directory is intentionally a capability map, not just a regression

--- a/crates/test-utils/src/fixture_dbs.rs
+++ b/crates/test-utils/src/fixture_dbs.rs
@@ -417,7 +417,7 @@ pub const FIXTURE_NODES_CANONICAL: FixtureDb = FixtureDb {
     bm25_index_expected: false,
     embedding: None,
     last_updated: "2026-05-17",
-    notes: "Canonical current-schema fixture_nodes backup for the normal type-resolution profile. It is imported as a plain active fixture; typed_type_graph workspace builds import the same code graph without claiming typed graph fixture coverage. Regeneration intentionally uses setup_db_full_multi_embedding so the saved snapshot includes the current multi-embedding schema relations expected by downstream tests without seeding local vectors.",
+    notes: "Canonical current-schema fixture_nodes backup for the normal type-resolution profile. It is imported as a plain active fixture without typed graph relations. Regeneration intentionally uses setup_db_full_multi_embedding so the saved snapshot includes the current multi-embedding schema relations expected by downstream tests without seeding local vectors.",
 };
 
 pub const FIXTURE_NODES_LOCAL_EMBEDDINGS: FixtureDb = FixtureDb {
@@ -549,7 +549,7 @@ pub const CORPUS_SEMVER_TYPE_GRAPH: FixtureDb = FixtureDb {
     bm25_index_expected: false,
     embedding: None,
     last_updated: "2026-05-17",
-    notes: "Corpus-backed type graph contract fixture for graphRAG traversal tests over semver's VersionReq/Version/Comparator type surface. Recreate with `cargo run -p xtask --features ploke-db/typed_type_graph,ploke-transform/typed_type_graph,syn_parser/typed_type_graph -- recreate-backup-db --fixture corpus_semver_type_graph`.",
+    notes: "Corpus-backed type graph contract fixture for graphRAG traversal tests over semver's VersionReq/Version/Comparator type surface. Recreate with `cargo run -p xtask -- recreate-backup-db --fixture corpus_semver_type_graph`.",
 };
 
 pub const CORPUS_SEMVER_OPENROUTER_EMBEDDINGS: FixtureDb = FixtureDb {


### PR DESCRIPTION
Removes feature gates from DB import and type_graph query tests.