### PR TITLE
chore(rag,tui): enable type-context expansion unconditionally

### DIFF
--- a/crates/ploke-rag/Cargo.toml
+++ b/crates/ploke-rag/Cargo.toml
@@ -28,4 +28,3 @@ criterion = { version = "0.7", features = ["async_tokio"] }
 
 [features]
 default = []
-typed_type_graph = ["ploke-db/typed_type_graph"]

--- a/crates/ploke-rag/src/core/mod.rs
+++ b/crates/ploke-rag/src/core/mod.rs
@@ -14,7 +14,6 @@ use ploke_embed::indexer::EmbeddingProcessor;
 use ploke_embed::runtime::EmbeddingRuntime;
 use ploke_io::IoManagerHandle;
 use std::collections::HashMap;
-#[cfg(feature = "typed_type_graph")]
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
@@ -85,7 +84,7 @@ pub struct TypeContextConfig {
 impl Default for TypeContextConfig {
     fn default() -> Self {
         Self {
-            enabled: cfg!(feature = "typed_type_graph"),
+            enabled: true,
             max_seed_hits: 12,
             max_expanded_hits: 48,
             score_factor: 0.6,
@@ -144,7 +143,6 @@ impl Reranker for NoopReranker {
     }
 }
 
-#[cfg(feature = "typed_type_graph")]
 fn type_context_kind(relation: TypeContextRelation) -> TypeContextKind {
     match relation {
         TypeContextRelation::SameResolvedType => TypeContextKind::SameResolvedType,
@@ -200,7 +198,6 @@ impl RagService {
         })
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn apply_type_context_gate(db: &Database, cfg: &mut RagConfig) -> Result<bool, RagError> {
         if !cfg.type_context.enabled {
             return Ok(false);
@@ -213,11 +210,6 @@ impl RagService {
         );
         cfg.type_context.enabled = false;
         Ok(true)
-    }
-
-    #[cfg(not(feature = "typed_type_graph"))]
-    fn apply_type_context_gate(_db: &Database, _cfg: &mut RagConfig) -> Result<bool, RagError> {
-        Ok(false)
     }
 
     /// Construct a new RAG service, starting the BM25 service actor.
@@ -619,7 +611,6 @@ impl RagService {
         Ok(all_results)
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn expand_hits_with_type_context(
         &self,
         hits: &[(Uuid, f32)],
@@ -724,14 +715,6 @@ impl RagService {
         );
         expanded_context.retain(|id, _| materialized_ids.contains(id));
         Ok((merged, expanded_context))
-    }
-
-    #[cfg(not(feature = "typed_type_graph"))]
-    fn expand_hits_with_type_context(
-        &self,
-        hits: &[(Uuid, f32)],
-    ) -> Result<(Vec<(Uuid, f32)>, HashMap<Uuid, TypeContextInfo>), RagError> {
-        Ok((hits.to_vec(), HashMap::new()))
     }
 
     /// High-level API: retrieve and assemble a context using the chosen strategy and budget.

--- a/crates/ploke-rag/src/core/unit_tests.rs
+++ b/crates/ploke-rag/src/core/unit_tests.rs
@@ -16,20 +16,16 @@ mod tests {
     use std::{collections::BTreeMap, default, ops::Deref, sync::Arc};
 
     use crate::{ApproxCharTokenizer, AssemblyPolicy, RetrievalStrategy, TokenBudget};
-    #[cfg(feature = "typed_type_graph")]
     use cozo::DataValue;
     use itertools::Itertools;
     use lazy_static::lazy_static;
-    #[cfg(feature = "typed_type_graph")]
     use ploke_core::rag_types::TypeContextKind;
     use ploke_core::{CrateId, EmbeddingData, RetrievalScope};
-    #[cfg(feature = "typed_type_graph")]
     use ploke_db::get_by_id::{GetNodeInfo, NodePaths};
     use ploke_db::{
         Database, create_index_primary_with_index,
         multi_embedding::{db_ext::EmbeddingExt, debug::DebugAll, hnsw_ext::HnswExt},
     };
-    #[cfg(feature = "typed_type_graph")]
     use ploke_db::{DbError, TypeContextSeed, TypeUseCoordinate, TypeUseRoot, to_uuid};
     use ploke_embed::{
         indexer::{EmbeddingProcessor, EmbeddingSource},
@@ -38,7 +34,6 @@ mod tests {
     };
     use ploke_error::Error;
     use ploke_io::IoManagerHandle;
-    #[cfg(feature = "typed_type_graph")]
     use ploke_test_utils::{
         ContainingOwnerSelector, CoordinateSpec, OwnerSelector, ShapePipelineCoverage,
         TargetSelector, TypeShapeCase, positive_type_shape_cases, setup_db_full_multi_embedding,
@@ -86,7 +81,6 @@ mod tests {
         RagService::new(db, embedding_runtime).expect("valid db and RagService constructor args")
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn init_test_rag_mock(db: Arc<Database>) -> RagService {
         let embedding_runtime = Arc::new(EmbeddingRuntime::from_shared_set(
             Arc::clone(&db.active_embedding_set),
@@ -132,7 +126,6 @@ mod tests {
             .expect("valid db and RagService constructor args")
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn unique_id_by_name(db: &Database, relation: &str, name: &str) -> Result<Uuid, Error> {
         let script = format!(
             r#"?[id] :=
@@ -148,7 +141,6 @@ mod tests {
         to_uuid(&rows.rows[0][0]).map_err(Error::from)
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn impl_self_target_for_method_name(db: &Database, method_name: &str) -> Result<Uuid, Error> {
         let script = format!(
             r#"?[target_id] :=
@@ -171,12 +163,10 @@ mod tests {
         to_uuid(&rows.rows[0][0]).map_err(Error::from)
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn covers(case: &TypeShapeCase, coverage: ShapePipelineCoverage) -> bool {
         case.coverage.iter().any(|candidate| *candidate == coverage)
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn resolve_matrix_owner(db: &Database, selector: OwnerSelector) -> Result<Uuid, DbError> {
         match selector {
             OwnerSelector::FunctionInModule { module_path, name } => {
@@ -286,7 +276,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn resolve_matrix_target(
         db: &Database,
         owner_id: Uuid,
@@ -345,7 +334,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn resolve_containing_owner(
         db: &Database,
         selector: ContainingOwnerSelector,
@@ -379,7 +367,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn resolve_matrix_coordinate(
         db: &Database,
         spec: CoordinateSpec,
@@ -438,7 +425,6 @@ mod tests {
         })
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn exactly_one_matrix_root(
         db: &Database,
         owner_id: Uuid,
@@ -461,7 +447,6 @@ mod tests {
         Ok(matching[0].clone())
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn one_uuid(db: &Database, script: &str) -> Result<Uuid, DbError> {
         let rows = db.raw_query(script)?;
         assert_eq!(
@@ -473,7 +458,6 @@ mod tests {
         to_uuid(&rows.rows[0][0])
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn one_uuid_by_file_suffix(
         db: &Database,
         script: &str,
@@ -500,7 +484,6 @@ mod tests {
         to_uuid(&matching[0])
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn module_path(items: &[&str]) -> String {
         format!(
             "[{}]",
@@ -512,7 +495,6 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn function_in_module_query(module_path_items: &[&str], name: &str) -> String {
         let module_path = module_path(module_path_items);
         format!(
@@ -522,12 +504,10 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn function_in_file_query(name: &str) -> String {
         item_in_file_query("function", name)
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn item_in_file_query(relation: &str, name: &str) -> String {
         format!(
             r#"?[id, file_path] :=
@@ -541,7 +521,6 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn struct_in_module_query(module_path_items: &[&str], name: &str) -> String {
         let module_path = module_path(module_path_items);
         format!(
@@ -556,12 +535,10 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn struct_in_file_query(name: &str) -> String {
         item_in_file_query("struct", name)
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn trait_in_module_query(module_path_items: &[&str], name: &str) -> String {
         let module_path = module_path(module_path_items);
         format!(
@@ -576,12 +553,10 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn trait_in_file_query(name: &str) -> String {
         item_in_file_query("trait", name)
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn method_by_impl_self_query(self_type: &str, method: &str) -> String {
         format!(
             r#"?[method_id] :=
@@ -601,7 +576,6 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn method_by_impl_trait_self_query(trait_name: &str, self_type: &str, method: &str) -> String {
         format!(
             r#"?[method_id] :=
@@ -632,7 +606,6 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn method_by_raw_pointer_impl_query(trait_name: &str, mutable: bool, method: &str) -> String {
         format!(
             r#"?[method_id, file_path] :=
@@ -666,7 +639,6 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn impl_by_trait_query(trait_name: &str) -> String {
         format!(
             r#"?[impl_id, file_path] :=
@@ -691,7 +663,6 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn generic_type_param_id_by_owner_name(
         db: &Database,
         owner_id: Uuid,
@@ -710,7 +681,6 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn where_generic_param_bound_owner(
         db: &Database,
         containing_owner_id: Uuid,
@@ -753,7 +723,6 @@ mod tests {
         )
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn generic_type_name(db: &Database, target_id: Uuid) -> Result<String, DbError> {
         let rows = db.raw_query(&format!(
             r#"?[name] :=
@@ -1564,7 +1533,6 @@ is_file_module[id] := *file_mod{owner_id: id @ 'NOW'}
         Ok(())
     }
 
-    #[cfg(feature = "typed_type_graph")]
     async fn stale_plain_starting_db() -> Result<Arc<Database>, Error> {
         use ploke_test_utils::FIXTURE_NODES_CANONICAL;
         use ploke_test_utils::fixture_dbs::backup_fixture_path_or_seed;
@@ -1576,7 +1544,6 @@ is_file_module[id] := *file_mod{owner_id: id @ 'NOW'}
         Ok(Arc::new(db))
     }
 
-    #[cfg(feature = "typed_type_graph")]
     #[tokio::test]
     async fn type_context_disabled_safely_when_relations_absent() -> Result<(), Error> {
         init_tracing_once();
@@ -1614,7 +1581,6 @@ is_file_module[id] := *file_mod{owner_id: id @ 'NOW'}
         Ok(())
     }
 
-    #[cfg(feature = "typed_type_graph")]
     #[tokio::test]
     async fn type_context_expansion_adds_materializable_type_neighbors() -> Result<(), Error> {
         init_tracing_once();
@@ -1653,7 +1619,6 @@ is_file_module[id] := *file_mod{owner_id: id @ 'NOW'}
         Ok(())
     }
 
-    #[cfg(feature = "typed_type_graph")]
     #[tokio::test]
     async fn corpus_type_shape_matrix_expands_db_and_rag_type_context() -> Result<(), Error> {
         init_tracing_once();
@@ -1707,7 +1672,6 @@ is_file_module[id] := *file_mod{owner_id: id @ 'NOW'}
         Ok(())
     }
 
-    #[cfg(feature = "typed_type_graph")]
     #[tokio::test]
     async fn axum_struct_seed_materializes_nested_trait_object_target() -> Result<(), Error> {
         init_tracing_once();
@@ -1745,7 +1709,6 @@ is_file_module[id] := *file_mod{owner_id: id @ 'NOW'}
         Ok(())
     }
 
-    #[cfg(feature = "typed_type_graph")]
     #[tokio::test]
     async fn axum_boxed_into_route_sparse_context_emits_nested_trait_type_context()
     -> Result<(), Error> {
@@ -1806,7 +1769,6 @@ is_file_module[id] := *file_mod{owner_id: id @ 'NOW'}
         Ok(())
     }
 
-    #[cfg(feature = "typed_type_graph")]
     #[tokio::test]
     async fn chrono_single_day_owner_seeded_expands_weekday_type_context() -> Result<(), Error> {
         init_tracing_once();
@@ -1833,7 +1795,6 @@ is_file_module[id] := *file_mod{owner_id: id @ 'NOW'}
         Ok(())
     }
 
-    #[cfg(feature = "typed_type_graph")]
     #[tokio::test]
     async fn chrono_single_day_bm25_precise_query_retrieves_method_owner() -> Result<(), Error> {
         init_tracing_once();
@@ -1859,7 +1820,6 @@ is_file_module[id] := *file_mod{owner_id: id @ 'NOW'}
         Ok(())
     }
 
-    #[cfg(feature = "typed_type_graph")]
     #[tokio::test]
     async fn axum_map_layer_field_seeded_expands_layer_fn_type_context() -> Result<(), Error> {
         init_tracing_once();
@@ -1901,7 +1861,6 @@ is_file_module[id] := *file_mod{owner_id: id @ 'NOW'}
         Ok(())
     }
 
-    #[cfg(feature = "typed_type_graph")]
     #[tokio::test]
     async fn axum_map_bm25_precise_query_retrieves_map_struct() -> Result<(), Error> {
         init_tracing_once();
@@ -1928,7 +1887,6 @@ is_file_module[id] := *file_mod{owner_id: id @ 'NOW'}
         Ok(())
     }
 
-    #[cfg(feature = "typed_type_graph")]
     fn context_label(db: &Database, id: Uuid) -> String {
         db.paths_from_id(id)
             .ok()

--- a/crates/ploke-tui/Cargo.toml
+++ b/crates/ploke-tui/Cargo.toml
@@ -120,7 +120,6 @@ default = [
     "test_harness",
     "live_api_tests",
     "ploke-llm-refactor",
-    "typed_type_graph",
 ]
 tool_contracts = []
 flakey_test = ["live_api_tests"]
@@ -130,12 +129,6 @@ ploke-llm-refactor = []
 llm_refactor = []
 live_api_tests = []
 test_harness = []
-typed_type_graph = [
-    "syn_parser/typed_type_graph",
-    "ploke-transform/typed_type_graph",
-    "ploke-db/typed_type_graph",
-    "ploke-rag/typed_type_graph",
-]
 demo = []
 json_visitor = []
 convert_keyword_2015 = ["syn_parser/convert_keyword_2015"]

--- a/crates/ploke-tui/src/tools/request_code_context.rs
+++ b/crates/ploke-tui/src/tools/request_code_context.rs
@@ -364,7 +364,7 @@ mod gat_tests {
         assert!(params.search_term.is_none());
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     #[tokio::test]
     async fn request_code_context_degrades_on_non_typed_db() -> color_eyre::Result<()> {
         use crate::app::commands::harness::TestRuntime;
@@ -544,7 +544,7 @@ mod gat_tests {
         Ok(())
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     #[tokio::test]
     #[ignore = "quarantined: do not force BM25/top_k behavior to satisfy matrix payload assertions"]
     async fn request_code_context_tool_emits_matrix_type_context() -> color_eyre::Result<()> {
@@ -682,7 +682,7 @@ mod gat_tests {
         Ok(())
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "live OpenRouter model/tool matrix test; requires OPENROUTER_API_KEY"]
     async fn live_request_code_context_matrix_uses_production_tool_payload()
@@ -871,7 +871,7 @@ mod gat_tests {
         Ok(())
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn assert_matrix_payload_has_type_context(
         case: &ploke_test_utils::TypeShapeCase,
         expected_target_id: uuid::Uuid,
@@ -899,7 +899,7 @@ mod gat_tests {
         );
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn covers(
         case: &ploke_test_utils::TypeShapeCase,
         coverage: ploke_test_utils::ShapePipelineCoverage,
@@ -907,7 +907,7 @@ mod gat_tests {
         case.coverage.iter().any(|candidate| *candidate == coverage)
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn resolve_matrix_target(
         db: &ploke_db::Database,
         selector: ploke_test_utils::TargetSelector,
@@ -944,7 +944,7 @@ mod gat_tests {
         }
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn type_context_kind(
         relation: ploke_db::TypeContextRelation,
     ) -> ploke_core::rag_types::TypeContextKind {
@@ -979,7 +979,7 @@ mod gat_tests {
         }
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn resolve_matrix_expected_type_context_seed_ids(
         db: &ploke_db::Database,
         case: &ploke_test_utils::TypeShapeCase,
@@ -1015,7 +1015,7 @@ mod gat_tests {
         Ok(seeds)
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn resolve_matrix_owner(
         db: &ploke_db::Database,
         selector: ploke_test_utils::OwnerSelector,
@@ -1081,7 +1081,7 @@ mod gat_tests {
         }
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn one_uuid(db: &ploke_db::Database, script: &str) -> color_eyre::Result<uuid::Uuid> {
         let rows = db.raw_query(script)?;
         assert_eq!(
@@ -1093,7 +1093,7 @@ mod gat_tests {
         Ok(ploke_db::to_uuid(&rows.rows[0][0])?)
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn one_uuid_by_file_suffix(
         db: &ploke_db::Database,
         script: &str,
@@ -1120,7 +1120,7 @@ mod gat_tests {
         Ok(ploke_db::to_uuid(&matching[0])?)
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn module_path(items: &[&str]) -> String {
         format!(
             "[{}]",
@@ -1132,7 +1132,7 @@ mod gat_tests {
         )
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn function_in_module_query(module_path_items: &[&str], name: &str) -> String {
         let module_path = module_path(module_path_items);
         format!(
@@ -1142,17 +1142,17 @@ mod gat_tests {
         )
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn function_in_file_query(name: &str) -> String {
         item_in_file_query("function", name)
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn struct_in_file_query(name: &str) -> String {
         item_in_file_query("struct", name)
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn item_in_file_query(relation: &str, name: &str) -> String {
         format!(
             r#"?[id, file_path] :=
@@ -1166,7 +1166,7 @@ mod gat_tests {
         )
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn struct_in_module_query(module_path_items: &[&str], name: &str) -> String {
         let module_path = module_path(module_path_items);
         format!(
@@ -1181,12 +1181,12 @@ mod gat_tests {
         )
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn trait_in_file_query(name: &str) -> String {
         item_in_file_query("trait", name)
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn trait_in_module_query(module_path_items: &[&str], name: &str) -> String {
         let module_path = module_path(module_path_items);
         format!(
@@ -1201,7 +1201,7 @@ mod gat_tests {
         )
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn method_by_impl_self_query(self_type: &str, method: &str) -> String {
         format!(
             r#"?[method_id] :=
@@ -1221,7 +1221,7 @@ mod gat_tests {
         )
     }
 
-    #[cfg(all(feature = "test_harness", feature = "typed_type_graph"))]
+    #[cfg(feature = "test_harness")]
     fn method_by_impl_trait_self_query(trait_name: &str, self_type: &str, method: &str) -> String {
         format!(
             r#"?[method_id] :=


### PR DESCRIPTION
Removes typed_type_graph gates from ploke-rag and ploke-tui test harness.